### PR TITLE
DV-3249: Don't send crypto spam receipt

### DIFF
--- a/artifacts/dv-merchant.service
+++ b/artifacts/dv-merchant.service
@@ -12,7 +12,7 @@ ExecStart=/bin/bash /home/dv/merchant/start.sh
 
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=github.com/dv-net/dv-merchant
+SyslogIdentifier=dv-merchant
 
 [Install]
 WantedBy=multi-user.target

--- a/cmd/console/commands.go
+++ b/cmd/console/commands.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dv-net/dv-merchant/internal/event"
 	"github.com/dv-net/dv-merchant/internal/service/currconv"
 	"github.com/dv-net/dv-merchant/internal/service/currency"
 	"github.com/dv-net/dv-merchant/internal/service/eproxy"
@@ -347,7 +348,9 @@ func prepareTransactionsCommands(currentAppVersion string) []*cli.Command {
 				}
 
 				eProxyService := eproxy.New(eprCl)
-				transactionService := transactions.New(lg, st, eProxyService, currConvService)
+				eventListener := event.New()
+
+				transactionService := transactions.New(lg, st, eProxyService, currConvService, eventListener, nil)
 
 				blockchains := ctx.StringSlice("blockchains")
 

--- a/internal/models/transaction.go
+++ b/internal/models/transaction.go
@@ -50,6 +50,8 @@ type ITransaction interface { //nolint:interfacebloat
 	GetStoreID() uuid.UUID
 	GetCurrencyID() string
 	IsConfirmed() bool
+	GetReceiptID() uuid.NullUUID
+	GetFee() decimal.Decimal
 }
 
 // transaction
@@ -102,6 +104,10 @@ func (tx Transaction) GetCurrencyID() string {
 	return tx.CurrencyID
 }
 
+func (tx Transaction) GetReceiptID() uuid.NullUUID { return tx.ReceiptID }
+
+func (tx Transaction) GetFee() decimal.Decimal { return tx.Fee }
+
 // Unconfirmed transaction
 
 func (utx UnconfirmedTransaction) GetID() uuid.UUID {
@@ -151,3 +157,7 @@ func (utx UnconfirmedTransaction) IsConfirmed() bool {
 func (utx UnconfirmedTransaction) GetCurrencyID() string {
 	return utx.CurrencyID
 }
+
+func (utx UnconfirmedTransaction) GetReceiptID() uuid.NullUUID { return uuid.NullUUID{} }
+
+func (utx UnconfirmedTransaction) GetFee() decimal.Decimal { return decimal.Zero }

--- a/internal/service/notify/service.go
+++ b/internal/service/notify/service.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/dv-net/dv-merchant/internal/delivery/http/request/notification_request"
-	"github.com/dv-net/dv-merchant/internal/event"
 	"github.com/dv-net/dv-merchant/internal/models"
 	"github.com/dv-net/dv-merchant/internal/service/permission"
 	"github.com/dv-net/dv-merchant/internal/service/setting"
@@ -55,7 +54,6 @@ type SendResult struct {
 type Service struct {
 	logger            logger.Logger
 	storage           storage.IStorage
-	eventListener     event.IListener
 	settingsSvc       setting.ISettingService
 	permissionService permission.IPermission
 
@@ -68,7 +66,6 @@ type Service struct {
 func New(
 	logger logger.Logger,
 	storage storage.IStorage,
-	eventListener event.IListener,
 	settingsSvc setting.ISettingService,
 	sender INotificationSender,
 	permSvc permission.IPermission,
@@ -77,7 +74,6 @@ func New(
 		logger:            logger,
 		storage:           storage,
 		settingsSvc:       settingsSvc,
-		eventListener:     eventListener,
 		permissionService: permSvc,
 		maxRetries:        DefaultMaxRetries,
 		sender:            sender,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -161,7 +161,6 @@ func NewServices(
 	}
 
 	eProxyService := eproxy.New(eprClient)
-	transactionService := transactions.New(logger, storage, eProxyService, currConvService)
 	receiptService := receipts.New(storage, currencyService)
 
 	processingMetrics, err := metrics.New()
@@ -196,8 +195,9 @@ func NewServices(
 
 	externalNotificationSender := external_sender.New(adminSvc, settingService)
 	notificationSender := notification_sender.New(logger, notificationDrivers, settingService, externalNotificationSender)
-	notificationService := notify.New(logger, storage, eventListener, settingService, notificationSender, permissionService)
+	notificationService := notify.New(logger, storage, settingService, notificationSender, permissionService)
 
+	transactionService := transactions.New(logger, storage, eProxyService, currConvService, eventListener, notificationService)
 	addressesService := address.New(conf, storage, logger, processingService)
 	withdrawalWalletService := withdrawal_wallet.New(storage, logger, currencyService, currConvService, processingService)
 	addressBookService := address_book.New(storage, logger, currencyService, withdrawalWalletService, processingService)
@@ -222,7 +222,7 @@ func NewServices(
 	systemService := system.New(settingService, permissionService, adminSvc, logger, appVersion, commitHash, conf, analyticsService)
 
 	dictionaryService := dictionary.New(storage, exrateService, systemService)
-	callbackService := callback.New(logger, eventListener, storage, transactionService, transactionService, storeService, currConvService, receiptService, notificationService)
+	callbackService := callback.New(logger, eventListener, storage, transactionService, transactionService, storeService, currConvService, receiptService)
 
 	exchangeManager := exchange_manager.NewManager(logger, storage, currConvService)
 	exchangeRulesService := exchange_rules.NewService(logger, storage, exchangeManager)

--- a/internal/service/store/service.go
+++ b/internal/service/store/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dv-net/dv-merchant/internal/service/exrate"
 	"github.com/dv-net/dv-merchant/internal/service/notify"
 	"github.com/dv-net/dv-merchant/internal/service/processing"
+	"github.com/dv-net/dv-merchant/internal/service/transactions"
 	"github.com/dv-net/dv-merchant/internal/service/wallet"
 	"github.com/dv-net/dv-merchant/internal/service/webhook"
 	"github.com/dv-net/dv-merchant/internal/storage"
@@ -86,9 +87,9 @@ func New(
 		processingSvc:       processingSvc,
 	}
 	// register event
-	srv.eventListener.Register(DepositReceivedEventType, srv.handleDepositReceived)
-	srv.eventListener.Register(DepositUnconfirmedEventType, srv.handleDepositReceived)
-	srv.eventListener.Register(WithdrawalFromProcessingReceivedEventType, srv.handleWithdrawalReceived)
+	srv.eventListener.Register(transactions.DepositReceivedEventType, srv.handleDepositReceived)
+	srv.eventListener.Register(transactions.DepositUnconfirmedEventType, srv.handleDepositReceived)
+	srv.eventListener.Register(transactions.WithdrawalFromProcessingReceivedEventType, srv.handleWithdrawalReceived)
 
 	return srv
 }

--- a/internal/service/store/webhook.go
+++ b/internal/service/store/webhook.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dv-net/dv-merchant/internal/service/transactions"
 	"github.com/dv-net/dv-merchant/internal/storage/repos/repo_store_currencies"
 	"github.com/dv-net/dv-merchant/internal/util"
 
@@ -89,7 +90,7 @@ func (s *Service) DeleteStoreWebhooks(ctx context.Context, id uuid.UUID, opts ..
 }
 
 func (s *Service) handleDepositReceived(ev event.IEvent) error {
-	convertedEv, ok := ev.(TransactionEvent)
+	convertedEv, ok := ev.(transactions.TransactionEvent)
 	if !ok {
 		return fmt.Errorf("invalid event type %s", ev.Type())
 	}
@@ -118,11 +119,11 @@ func (s *Service) handleDepositReceived(ev event.IEvent) error {
 		return nil
 	}
 
-	return s.processWebhooksByTransactionEvent(ev, DepositReceivedEventType, payload)
+	return s.processWebhooksByTransactionEvent(ev, transactions.DepositReceivedEventType, payload)
 }
 
 func (s *Service) handleWithdrawalReceived(ev event.IEvent) error {
-	convertedEv, ok := ev.(WithdrawalFromProcessingReceivedEvent)
+	convertedEv, ok := ev.(transactions.WithdrawalFromProcessingReceivedEvent)
 	if !ok {
 		return fmt.Errorf("invalid event type %s", ev.Type())
 	}
@@ -151,7 +152,7 @@ func (s *Service) handleWithdrawalReceived(ev event.IEvent) error {
 		return fmt.Errorf("prepare withdrawal hook payload: %w", err)
 	}
 
-	return s.processWebhooksByTransactionEvent(ev, WithdrawalFromProcessingReceivedEventType, preparedPayload)
+	return s.processWebhooksByTransactionEvent(ev, transactions.WithdrawalFromProcessingReceivedEventType, preparedPayload)
 }
 
 func (s *Service) SendWebhookManual(ctx context.Context, txID, userID uuid.UUID) error {
@@ -270,7 +271,7 @@ func (s *Service) processWebhooksByTransactionEvent(
 	eventType string,
 	hookPayload []byte,
 ) error {
-	txCreatedEvent, ok := ev.(TransactionEvent)
+	txCreatedEvent, ok := ev.(transactions.TransactionEvent)
 	if !ok || txCreatedEvent.EventType() != eventType {
 		return nil
 	}

--- a/internal/service/transactions/event_handler.go
+++ b/internal/service/transactions/event_handler.go
@@ -1,0 +1,70 @@
+package transactions
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/dv-net/dv-merchant/internal/event"
+	"github.com/dv-net/dv-merchant/internal/models"
+	"github.com/dv-net/dv-merchant/internal/service/notify"
+	"github.com/dv-net/dv-merchant/internal/util"
+	"github.com/shopspring/decimal"
+)
+
+func (s *Service) handleDepositReceiptSent(ev event.IEvent) error {
+	convertedEv, ok := ev.(TransactionEvent)
+	if !ok {
+		return fmt.Errorf("invalid event type %s", ev.Type())
+	}
+
+	storeData := convertedEv.GetStore()
+	tx := convertedEv.GetTx()
+	currency := convertedEv.GetCurrency()
+	userEmail := convertedEv.GetWalletEmail()
+	usdFee := convertedEv.GetUsdFee()
+
+	if userEmail == "" {
+		s.log.Info("Email not sent: no user email provided")
+		return nil
+	}
+
+	if tx.GetAmountUsd().LessThan(storeData.MinimalPayment) {
+		s.log.Infof("Email not sent: txAmount=%s < minimalPayment=%s",
+			tx.GetAmountUsd().String(), storeData.MinimalPayment.String(),
+		)
+		return nil
+	}
+
+	if s.notificationService == nil {
+		s.log.Info("No notification service disabled")
+		return nil
+	}
+
+	go s.notificationService.SendSystemEmail(context.Background(), models.NotificationTypeUserCryptoReceipt, userEmail, &notify.UserCryptoReceiptNotificationData{
+		Email:                userEmail,
+		Language:             convertedEv.GetWalletLocale(),
+		PaymentStatus:        notify.PaymentStatusCompleted.String(),
+		PaymentType:          notify.PaymentTypeDeposit.String(),
+		ReceiptId:            tx.GetReceiptID().UUID.String(),
+		PaymentDate:          tx.GetCreatedAt().Time.Format(time.DateTime),
+		UsdAmount:            tx.GetAmountUsd().RoundDown(2).String(),
+		TokenAmount:          tx.GetAmount().String(),
+		TokenSymbol:          currency.Code,
+		TransactionHash:      tx.GetTxHash(),
+		BlockchainCurrencyID: tx.GetCurrencyID(),
+		BlockchainName:       strings.ToUpper(currency.Blockchain.String()),
+		ExchangeRate:         convertedEv.GetExchangeRate().String(),
+		NetworkFeeAmount:     tx.GetFee().String(),
+		NetworkFeeUSD:        usdFee.String(),
+		NetworkFeeCurrency:   currency.Code,
+		PlatformFeeAmount:    decimal.Zero.String(),
+		PlatformFeeUSD:       decimal.Zero.String(),
+		PlatformFeeCurrency:  currency.Code,
+	}, &models.NotificationArgs{
+		StoreID: util.Pointer(storeData.ID),
+	})
+
+	return nil
+}

--- a/internal/service/webhook/service.go
+++ b/internal/service/webhook/service.go
@@ -3,7 +3,6 @@ package webhook
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"math"
@@ -11,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/goccy/go-json"
 	"github.com/jackc/pgx/v5"
 
 	"github.com/dv-net/dv-merchant/internal/config"


### PR DESCRIPTION
refactor: reorganize `transactions` package and streamline event handling

- Moved event-related logic from `store` and `webhook` into `transactions`.
- Standardized event registration and handling across services.
- Introduced `DepositReceiptSent` event type with new handler for notification management.
- Updated `Transaction` model to include `ReceiptID` and `Fee` attributes.
- Adjusted dependencies and structure in `callback`, `service`, and related components to accommodate changes.