### PR TITLE
DV-3359: feat: add log memory buffer and last logs endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Mask response with CEX API keys [DV-3332]
 - Add Handler for confirm selected wallet currency[DV-3354]
 - Add validation for withdrawal exchange wallet by blockchain [DV-3326]
+- Add log memory buffer [DV-3359]
 
 ## [0.6.1] - 2025-08-11
 - Internal/External API withdrawal route now takes a random store ID related to the user for internal requests, and uses the store ID from the XApiKey header for external requests. [DV-2704]

--- a/cmd/console/commands.go
+++ b/cmd/console/commands.go
@@ -332,7 +332,7 @@ func prepareTransactionsCommands(currentAppVersion string) []*cli.Command {
 					return fmt.Errorf("storage init: %w", err)
 				}
 
-				dvAdmin := admin_gateway.New(conf.Admin.BaseURL, currentAppVersion, lg)
+				dvAdmin := admin_gateway.New(conf.Admin.BaseURL, currentAppVersion, lg, conf.Admin.LogStatus)
 				currService := currency.New(conf, st)
 				exrateService, err := exrate.New(conf, currService, lg, st, dvAdmin)
 				if err != nil {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1771,6 +1771,51 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/dv-admin/logs/last": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logs"
+                ],
+                "summary": "Get last logs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/dv-admin/logs/{slug}": {
             "get": {
                 "security": [
@@ -10215,10 +10260,13 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "page": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "page_size": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 1
                 },
                 "slug": {
                     "type": "string"
@@ -12355,6 +12403,20 @@ const docTemplate = `{
                     "items": {
                         "type": "string"
                     }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse"
                 },
                 "message": {
                     "type": "string"
@@ -14860,6 +14922,17 @@ const docTemplate = `{
                 }
             }
         },
+        "github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO"
+                    }
+                }
+            }
+        },
         "github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.LogData": {
             "type": "object",
             "properties": {
@@ -15332,6 +15405,20 @@ const docTemplate = `{
                 },
                 "resolution": {
                     "$ref": "#/definitions/github_com_dv-net_dv-merchant_internal_storage_repos_repo_transactions.Resolution"
+                }
+            }
+        },
+        "github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1764,6 +1764,51 @@
                 }
             }
         },
+        "/v1/dv-admin/logs/last": {
+            "get": {
+                "security": [
+                    {
+                        "Bearer": []
+                    }
+                ],
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Logs"
+                ],
+                "summary": "Get last logs",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    },
+                    "422": {
+                        "description": "Unprocessable Entity",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    },
+                    "503": {
+                        "description": "Service Unavailable",
+                        "schema": {
+                            "$ref": "#/definitions/APIErrors"
+                        }
+                    }
+                }
+            }
+        },
         "/v1/dv-admin/logs/{slug}": {
             "get": {
                 "security": [
@@ -10208,10 +10253,13 @@
                     "type": "string"
                 },
                 "page": {
-                    "type": "integer"
+                    "type": "integer",
+                    "minimum": 1
                 },
                 "page_size": {
-                    "type": "integer"
+                    "type": "integer",
+                    "maximum": 100,
+                    "minimum": 1
                 },
                 "slug": {
                     "type": "string"
@@ -12348,6 +12396,20 @@
                     "items": {
                         "type": "string"
                     }
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "integer"
+                },
+                "data": {
+                    "$ref": "#/definitions/github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse"
                 },
                 "message": {
                     "type": "string"
@@ -14853,6 +14915,17 @@
                 }
             }
         },
+        "github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO"
+                    }
+                }
+            }
+        },
         "github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.LogData": {
             "type": "object",
             "properties": {
@@ -15325,6 +15398,20 @@
                 },
                 "resolution": {
                     "$ref": "#/definitions/github_com_dv-net_dv-merchant_internal_storage_repos_repo_transactions.Resolution"
+                }
+            }
+        },
+        "github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO": {
+            "type": "object",
+            "properties": {
+                "level": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "time": {
+                    "type": "string"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -650,8 +650,11 @@ definitions:
       date_to:
         type: string
       page:
+        minimum: 1
         type: integer
       page_size:
+        maximum: 100
+        minimum: 1
         type: integer
       slug:
         type: string
@@ -2059,6 +2062,15 @@ definitions:
         items:
           type: string
         type: array
+      message:
+        type: string
+    type: object
+  JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse:
+    properties:
+      code:
+        type: integer
+      data:
+        $ref: '#/definitions/github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse'
       message:
         type: string
     type: object
@@ -3757,6 +3769,13 @@ definitions:
       withdraw_quota_per_day:
         type: string
     type: object
+  github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.GetLastLogsResponse:
+    properties:
+      items:
+        items:
+          $ref: '#/definitions/github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO'
+        type: array
+    type: object
   github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response.LogData:
     properties:
       created_at:
@@ -4087,6 +4106,15 @@ definitions:
         type: string
       resolution:
         $ref: '#/definitions/github_com_dv-net_dv-merchant_internal_storage_repos_repo_transactions.Resolution'
+    type: object
+  github_com_dv-net_dv-merchant_pkg_logger.MemoryLogDTO:
+    properties:
+      level:
+        type: string
+      message:
+        type: string
+      time:
+        type: string
     type: object
   map_string_CombinedStats:
     additionalProperties:
@@ -5277,6 +5305,34 @@ paths:
       security:
       - Bearer: []
       summary: Get logs by slug
+      tags:
+      - Logs
+  /v1/dv-admin/logs/last:
+    get:
+      consumes:
+      - application/json
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/JSONResponse-github_com_dv-net_dv-merchant_internal_delivery_http_responses_log_response_GetLastLogsResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/APIErrors'
+        "422":
+          description: Unprocessable Entity
+          schema:
+            $ref: '#/definitions/APIErrors'
+        "503":
+          description: Service Unavailable
+          schema:
+            $ref: '#/definitions/APIErrors'
+      security:
+      - Bearer: []
+      summary: Get last logs
       tags:
       - Logs
   /v1/dv-admin/notifications/history:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type (
 	AdminConfig struct {
 		BaseURL             string        `yaml:"base_url" default:"https://api.dv.net/"`
 		PingVersionInterval time.Duration `yaml:"ping_version_interval" default:"1h"`
+		LogStatus           bool          `yaml:"log_status" default:"false"`
 	}
 
 	NotifyConfig struct {

--- a/internal/delivery/http/handlers/log.go
+++ b/internal/delivery/http/handlers/log.go
@@ -3,12 +3,12 @@ package handlers
 import (
 	"errors"
 
+	"github.com/dv-net/dv-merchant/internal/delivery/http/responses/log_response"
+	"github.com/dv-net/dv-merchant/internal/delivery/middleware"
+	"github.com/dv-net/dv-merchant/internal/models"
 	"github.com/dv-net/dv-merchant/internal/tools/apierror"
 	"github.com/dv-net/dv-merchant/internal/tools/converters"
 	"github.com/dv-net/dv-merchant/internal/tools/response"
-
-	// Blank import for swaggen
-	_ "github.com/dv-net/dv-merchant/internal/delivery/http/responses/log_response"
 
 	"github.com/gofiber/fiber/v3"
 )
@@ -68,8 +68,31 @@ func (h *Handler) getLogsBySlug(c fiber.Ctx) error {
 	return c.JSON(response.OkByData(converters.GetAllLogsResponse(messages)))
 }
 
+// @Summary	Get last logs
+// @Description
+// @Tags		Logs
+// @Accept		json
+// @Produce	json
+// @Success	200	{object}	response.Result[log_response.GetLastLogsResponse]
+// @Failure	404	{object}	apierror.Errors
+// @Failure	422	{object}	apierror.Errors
+// @Failure	503	{object}	apierror.Errors
+// @Router		/v1/dv-admin/logs/last [get]
+// @Security	Bearer
+func (h *Handler) getLogs(c fiber.Ctx) error {
+	_, err := loadAuthUser(c)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(response.OkByData(log_response.GetLastLogsResponse{
+		Items: h.logger.LastLogs(),
+	}))
+}
+
 func (h *Handler) initLogsRoutes(v1 fiber.Router) {
-	logs := v1.Group("/logs")
+	logs := v1.Group("/logs", middleware.CasbinMiddleware(h.services.PermissionService, []models.UserRole{models.UserRoleRoot}))
 	logs.Get("/", h.getLogsType)
+	logs.Get("/last", h.getLogs)
 	logs.Get("/:slug", h.getLogsBySlug)
 }

--- a/internal/delivery/http/responses/log_response/logs.go
+++ b/internal/delivery/http/responses/log_response/logs.go
@@ -3,6 +3,7 @@ package log_response
 import (
 	"time"
 
+	"github.com/dv-net/dv-merchant/pkg/logger"
 	"github.com/google/uuid"
 )
 
@@ -27,3 +28,7 @@ type LogData struct {
 type GetLogsResponse struct {
 	Items []LogData `json:"items"`
 } // @name GetMonitorTypesResponse
+
+type GetLastLogsResponse struct {
+	Items []logger.MemoryLogDTO `json:"items"`
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -135,7 +135,7 @@ func NewServices(
 	currencyService := currency.New(conf, storage)
 	eventListener := event.New()
 
-	adminSvc := admin_gateway.New(conf.Admin.BaseURL, appVersion, logger)
+	adminSvc := admin_gateway.New(conf.Admin.BaseURL, appVersion, logger, conf.Admin.LogStatus)
 	exrateService, err := exrate.New(conf, currencyService, logger, storage, adminSvc)
 	if err != nil {
 		logger.Error("init currency exchange rate service failed", err)

--- a/pkg/logger/constant.go
+++ b/pkg/logger/constant.go
@@ -11,3 +11,5 @@ const (
 func (s LogStatus) String() string {
 	return string(s)
 }
+
+const LogBufferSize = 1000

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,11 +2,15 @@ package logger
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"sync"
+	"time"
 
 	"github.com/dv-net/mx/logger"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type sugaredLogger = zap.SugaredLogger
@@ -14,6 +18,14 @@ type sugaredLogger = zap.SugaredLogger
 type Logger interface {
 	logger.ExtendedLogger
 	WithDBSyncer(dbSyncer *DBWriteSyncer)
+
+	LastLogs() []MemoryLogDTO
+}
+
+type MemoryLogDTO struct {
+	Time    time.Time `json:"time"`
+	Level   string    `json:"level"`
+	Message string    `json:"message"`
 }
 
 type WrappedLogger struct {
@@ -21,16 +33,12 @@ type WrappedLogger struct {
 	dbSyncer *DBWriteSyncer
 
 	*sugaredLogger
+	// log buffer
+	mu       sync.Mutex
+	logs     []MemoryLogDTO
+	capacity int
+	minLevel zapcore.Level
 }
-
-func (l *WrappedLogger) Sugar() *zap.SugaredLogger {
-	return l.sugaredLogger
-}
-
-func (l *WrappedLogger) Std() *log.Logger {
-	return zap.NewStdLog(l.Desugar())
-}
-
 type LogPrams struct {
 	Status    LogStatus
 	Slug      string
@@ -40,52 +48,147 @@ type LogPrams struct {
 var _ Logger = (*WrappedLogger)(nil)
 
 func New(appVersion string, conf logger.Config) Logger {
-	log := logger.NewExtended(
+	l := logger.NewExtended(
 		logger.WithLogFormat(logger.LoggerFormatJSON),
 		logger.WithAppVersion(appVersion),
 		logger.WithConfig(conf),
 	)
 
-	return &WrappedLogger{logger: log, sugaredLogger: log.Sugar()}
+	return &WrappedLogger{
+		logger:        l,
+		sugaredLogger: l.Sugar(),
+		capacity:      LogBufferSize,
+		logs:          make([]MemoryLogDTO, 0, LogBufferSize),
+		minLevel:      safeLevel(conf.Level),
+	}
+}
+
+func (l *WrappedLogger) addToMemory(level, msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if l.logs == nil {
+		l.logs = make([]MemoryLogDTO, 0, l.capacity)
+	}
+
+	newLog := MemoryLogDTO{
+		Time:    time.Now(),
+		Level:   level,
+		Message: msg,
+	}
+
+	l.logs = append([]MemoryLogDTO{newLog}, l.logs...)
+
+	if len(l.logs) > l.capacity {
+		l.logs = l.logs[:l.capacity]
+	}
+}
+
+func (l *WrappedLogger) LastLogs() []MemoryLogDTO {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return append([]MemoryLogDTO(nil), l.logs...)
+}
+
+func (l *WrappedLogger) Debug(args ...any) {
+	l.logger.Debug(args...)
+	l.log(logger.LogLevelDebug, fmt.Sprint(args...))
+}
+
+func (l *WrappedLogger) Debugln(args ...any) {
+	l.logger.Debugln(args...)
+	l.log(logger.LogLevelDebug, fmt.Sprintln(args...))
+}
+
+func (l *WrappedLogger) Debugf(template string, args ...any) {
+	l.logger.Debugf(template, args...)
+	l.log(logger.LogLevelDebug, fmt.Sprintf(template, args...))
+}
+
+func (l *WrappedLogger) Debugw(msg string, keysAndValues ...any) {
+	l.logger.Debugw(msg, keysAndValues...)
+	l.log(logger.LogLevelDebug, msg, keysAndValues...)
+}
+
+func (l *WrappedLogger) Info(args ...any) {
+	l.logger.Info(args...)
+	l.log(logger.LogLevelInfo, fmt.Sprint(args...))
+}
+
+func (l *WrappedLogger) Infoln(args ...any) {
+	l.logger.Infoln(args...)
+	l.log(logger.LogLevelInfo, fmt.Sprintln(args...))
+}
+
+func (l *WrappedLogger) Infof(template string, args ...any) {
+	l.logger.Infof(template, args...)
+	l.log(logger.LogLevelInfo, fmt.Sprintf(template, args...))
+}
+
+func (l *WrappedLogger) Infow(msg string, keysAndValues ...any) {
+	l.logger.Infow(msg, keysAndValues...)
+	l.log(logger.LogLevelInfo, msg, keysAndValues...)
+}
+
+func (l *WrappedLogger) Warn(args ...any) {
+	l.logger.Warn(args...)
+	l.log(logger.LogLevelWarn, fmt.Sprint(args...))
+}
+
+func (l *WrappedLogger) Warnln(args ...any) {
+	l.logger.Warnln(args...)
+	l.log(logger.LogLevelWarn, fmt.Sprintln(args...))
 }
 
 func (l *WrappedLogger) Warnf(template string, args ...any) {
 	l.logger.Warnf(template, args...)
-	var logParams *LogPrams
-	if len(args) > 0 {
-		if p, ok := args[0].(*LogPrams); ok {
-			logParams = p
-		}
-	}
-	if logParams != nil {
-		l.logToDB("WARN", template, logParams.Status.String(), logParams.ProcessID, logParams.Slug)
-	}
+	l.log(logger.LogLevelWarn, fmt.Sprintf(template, args...))
 }
 
 func (l *WrappedLogger) Warnw(msg string, keysAndValues ...any) {
 	l.logger.Warnw(msg, keysAndValues...)
-	var logParams *LogPrams
-	if len(keysAndValues) > 0 {
-		if p, ok := keysAndValues[0].(*LogPrams); ok {
-			logParams = p
-		}
-	}
-	if logParams != nil {
-		l.logToDB("WARN", msg, logParams.Status.String(), logParams.ProcessID, logParams.Slug)
-	}
+	l.log(logger.LogLevelWarn, msg, keysAndValues...)
 }
 
-func (l *WrappedLogger) Infow(msg string, params ...any) {
-	l.logger.Infow(msg, params...)
-	var logParams *LogPrams
-	if len(params) > 0 {
-		if p, ok := params[0].(*LogPrams); ok {
-			logParams = p
-		}
-	}
-	if logParams != nil {
-		l.logToDB("INFO", msg, logParams.Status.String(), logParams.ProcessID, logParams.Slug)
-	}
+func (l *WrappedLogger) Error(args ...any) {
+	l.logger.Error(args...)
+	l.log(logger.LogLevelError, fmt.Sprint(args...))
+}
+
+func (l *WrappedLogger) Errorln(args ...any) {
+	l.logger.Errorln(args...)
+	l.log(logger.LogLevelError, fmt.Sprintln(args...))
+}
+
+func (l *WrappedLogger) Errorf(template string, args ...any) {
+	l.logger.Errorf(template, args...)
+	l.log(logger.LogLevelError, fmt.Sprintf(template, args...))
+}
+
+func (l *WrappedLogger) Errorw(msg string, keysAndValues ...any) {
+	l.logger.Errorw(msg, keysAndValues...)
+	l.log(logger.LogLevelError, msg, keysAndValues...)
+}
+
+func (l *WrappedLogger) Fatal(args ...any) {
+	l.logger.Fatal(args...)
+	l.log(logger.LogLevelFatal, fmt.Sprint(args...))
+}
+
+func (l *WrappedLogger) Fatalln(args ...any) {
+	l.logger.Fatalln(args...)
+	l.log(logger.LogLevelFatal, fmt.Sprintln(args...))
+}
+
+func (l *WrappedLogger) Fatalf(template string, args ...any) {
+	l.logger.Fatalf(template, args...)
+	l.log(logger.LogLevelFatal, fmt.Sprintf(template, args...))
+}
+
+func (l *WrappedLogger) Fatalw(msg string, keysAndValues ...any) {
+	l.logger.Fatalw(msg, keysAndValues...)
+	l.log(logger.LogLevelFatal, msg, keysAndValues...)
 }
 
 func (l *WrappedLogger) logToDB(level string, msg string, status string, processID uuid.UUID, typeSlug string) {
@@ -105,4 +208,46 @@ func (l *WrappedLogger) logToDB(level string, msg string, status string, process
 
 func (l *WrappedLogger) WithDBSyncer(dbSyncer *DBWriteSyncer) {
 	l.dbSyncer = dbSyncer
+}
+
+func (l *WrappedLogger) Sugar() *zap.SugaredLogger {
+	return l.sugaredLogger
+}
+
+func (l *WrappedLogger) Std() *log.Logger {
+	return zap.NewStdLog(l.Desugar())
+}
+
+func (l *WrappedLogger) log(level logger.LogLevel, msg string, args ...any) {
+	if safeLevel(level) < l.minLevel {
+		return
+	}
+	var logParams *LogPrams
+	if len(args) > 0 {
+		if p, ok := args[0].(*LogPrams); ok {
+			logParams = p
+		}
+	}
+	if logParams != nil {
+		l.logToDB(level.String(), msg, logParams.Status.String(), logParams.ProcessID, logParams.Slug)
+	} else {
+		l.addToMemory(level.String(), msg)
+	}
+}
+
+func safeLevel(level logger.LogLevel) zapcore.Level {
+	switch level {
+	default:
+		return zapcore.InfoLevel
+	case logger.LogLevelDebug:
+		return zapcore.DebugLevel
+	case logger.LogLevelWarn:
+		return zapcore.WarnLevel
+	case logger.LogLevelError:
+		return zapcore.ErrorLevel
+	case logger.LogLevelPanic:
+		return zapcore.PanicLevel
+	case logger.LogLevelFatal:
+		return zapcore.FatalLevel
+	}
 }


### PR DESCRIPTION
- Enabled in-memory log buffering with a configurable capacity for recent log retrieval.
- Added `/v1/dv-admin/logs/last` endpoint to fetch the latest logs.
- Extended logger implementation to support buffered log storage and retrieval.
- Updated admin gateway and swagger documentation to include log status configuration.